### PR TITLE
Enable multi-workers, and make data loading faster

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -9,6 +9,10 @@ except ImportError:
 import os
 import re
 import logging
+import pickle
+import md5
+
+import config
 
 
 class MetricsError(Exception):
@@ -62,10 +66,27 @@ class Backend(object):
     def update_data(self, s_metrics):
         logging.debug("loading metrics")
         metrics = self.load_metrics()
-        logging.debug("listing targets")
+
+        logging.debug("updatinging targets")
         targets_all = s_metrics.list_targets(metrics)
-        logging.debug("listing graphs")
+        targets_all = targets_all.copy()
+        # Because "lambda" can not be pickled, I delete them in a copy of targets_all.
+        for k in targets_all.keys():
+            if targets_all[k]['config'].has_key('configure'):
+                del targets_all[k]['config']['configure']
+        open(config.targets_all_cache_file, 'w').write(pickle.dumps(targets_all))
+
+        logging.debug("updating graphs")
         graphs_all = s_metrics.list_graphs(metrics)
+        open(config.graphs_all_cache_file, 'w').write(pickle.dumps(graphs_all))
+
+    def load_data(self):
+        logging.debug("loading metrics")
+        metrics = self.load_metrics()
+        logging.debug("loading targets")
+        targets_all = pickle.loads(open('targets_all.cache').read())
+        logging.debug("loading graphs")
+        graphs_all = pickle.loads(open('graphs_all.cache').read())
 
         return (metrics, targets_all, graphs_all)
 

--- a/config.py
+++ b/config.py
@@ -3,4 +3,6 @@ anthracite_url = None
 listen_host = '0.0.0.0'  # defaults to "all interfaces"
 listen_port = 8080
 filename_metrics = 'metrics.json'
+targets_all_cache_file = 'targets_all.cache'
+graphs_all_cache_file = 'graphs_all.cache'
 log_file = 'graph-explorer.log'


### PR DESCRIPTION
- Make data loading faster

I cache these data("targets_all", "graphs_all") to disk files when run update_metrics.py,
then delete the urlopen in update_metrics.py, because app.py will reload these data by comparing `mtime` of these files when response /index.
- Enable multi-workers

When I tested multi-workers with gunicorn, I found it would refresh_data in a SINGLE worker. then I make app.py compare the mtime of these data files in each request to /index, if these files were modified, reload them.

It also works in a single worker as before, but some minutes faster, :) 
