### PR TITLE
enable dict style dashboard entry

### DIFF
--- a/templates/body.dashboard.tpl
+++ b/templates/body.dashboard.tpl
@@ -5,7 +5,7 @@
           <h2>{{dashboard}}</h2>
 <ul>
 % for q in queries:
-<li><a href="/index/{{q}}">{{q}}</a>
+<li><a href="/index/{{isinstance(q, dict) and q['query'] or q}}">{{isinstance(q, dict) and q['description'] or q}}</a>
 %end
 </ul>
        </div>


### PR DESCRIPTION
Make dashboard more readable: support "description" instead of query string.

Enable these styles:
( my script: dashboard/cpu.py )

``` python
queries = [
    'plugin=cpu type=user group by server',
    'plugin=cpu type=system group by server'
]
```

or

``` python
queries = [
    'plugin=cpu type=user group by server',
    {  
        'query': 'plugin=cpu type=system group by server',
        'description' : 'cpu system'
    }
]
```

or

``` python
queries = [
    {  
        'query': 'plugin=cpu type=user group by server',
        'description' : 'cpu user'
    },
    {  
        'query': 'plugin=cpu type=system group by server',
        'description' : 'cpu system'
    }
]
```
