### PR TITLE
Use shlex.split instead of split() (permit to use tags with spaces in them)

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,7 +127,7 @@ def parse_query(query_str):
 
     # split query_str into multiple patterns which are all matched independently
     # this allows you write patterns in any order, and also makes it easy to use negations
-    query['patterns'] += shlex.split(query_str)
+    query['patterns'] += shlex.split(query_str, comments=True)
     return query
 
 


### PR DESCRIPTION
- Permit the use of " " for tags named with a space in them
  - Allow to "comment" part of the query (by using # in front of the commented part)
