### PR TITLE
fix: targets_list is just query result

### DIFF
--- a/templates/graphs.tpl
+++ b/templates/graphs.tpl
@@ -34,7 +34,7 @@
         % end
         <!-- approximation of get_inspect_url(data, name) that works as long as list mode doesn't support sum by (or other kind of N metrics in 1 target) -->
         % for target_id in targets_list.iterkeys():
-            <a href="/inspect/{{targets_list[target_id]['graphite_metric']}}">{{target_id}}</a></br>
+            <a href="/inspect/{{targets_list[target_id]['id']}}">{{target_id}}</a></br>
         % end
     % end
 % else:


### PR DESCRIPTION
target_list (for 'list' queries) doesn't have graphite_metric field
