### PR TITLE
plugin for collectd-generated metrics in graphite

### DIFF
--- a/structured_metrics/plugins/__init__.py
+++ b/structured_metrics/plugins/__init__.py
@@ -98,8 +98,8 @@ class Plugin(object):
         return ' '.join(target_key)
 
     def __create_target(self, match, target_config):
-        tags = {'target_type': target_config['target_type'], 'plugin': self.classname_to_tag()}
-        tags.update(match.groupdict())
+        tags = match.groupdict()
+        tags.update({'target_type': target_config['target_type'], 'plugin': self.classname_to_tag()})
         target = {
             'config': target_config,
             'tags': tags,

--- a/structured_metrics/plugins/collectd.py
+++ b/structured_metrics/plugins/collectd.py
@@ -44,7 +44,7 @@ class CollectdPlugin(Plugin):
         'counter': ('1', 'rate')
     }
     targets = [{
-        'match': '^collectd\.(?P<server>.+?)\.(?P<plugin>.+?)(?:-(?P<plugin_instance>.+?))?\.(?P<type>.+?)(?:-(?P<type_instance>.+?))?\.(?P<value>.+)$',
+        'match': '^collectd\.(?P<server>.+?)\.(?P<collectd_plugin>.+?)(?:-(?P<collectd_plugin_instance>.+?))?\.(?P<type>.+?)(?:-(?P<type_instance>.+?))?\.(?P<value>.+)$',
         'target_type': 'unknown',
         'configure': [
             lambda self, target: self.add_tag(target, 'source', 'collectd'),


### PR DESCRIPTION
It contains (still incomplete) list of various types of metrics provided by collectd.
Includes a fix allowing plugin tag to be overridden by regex matcher.
