### PR TITLE
tell pytest not to recurse to 3rd-party modules

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-norecursedirs = structured_metrics/requests structured_metrics/elasticsearch-py structured_metrics/urllib3
+norecursedirs = structured_metrics/requests structured_metrics/urllib3
+    structured_metrics/elasticsearch-py paste


### PR DESCRIPTION
..or at least some of the 3rd-party modules. not sure if their tests are
broken or if they just don't run well in my configuration, but it's not
too important. they can be tested separately from graph-explorer.
