### PR TITLE
Various tweaks to be pylint-clean

### DIFF
--- a/.lint_exclusions
+++ b/.lint_exclusions
@@ -1,0 +1,4 @@
+bottle.py
+structured_metrics/urllib3
+structured_metrics/elasticsearch-py
+paste

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,23 @@
+[MASTER]
+profile=no
+ignore=
+persistent=no
+
+[REPORTS]
+output-format=colorized
+include-ids=yes
+files-output=no
+reports=no
+
+[FORMAT]
+;max-line-length=100
+max-line-length=200
+
+[MESSAGES CONTROL]
+disable=C0103,C0111,E1123,I0011,R0801,R0904,R0912,R0913,R0914,R0915,W0142,W0511
+
+[BASIC]
+bad-functions=eval,input,compile
+
+[TYPECHECK]
+ignored-classes=elasticsearch.client.cluster.ClusterClient

--- a/backend.py
+++ b/backend.py
@@ -7,6 +7,7 @@ from urlparse import urljoin
 
 class MetricsError(Exception):
     def __init__(self, msg, underlying_error):
+        Exception.__init__(self, msg, underlying_error)
         self.msg = str(msg)
         self.underlying_error = str(underlying_error)
 

--- a/convert.py
+++ b/convert.py
@@ -28,7 +28,7 @@ prefixes_IEC = {
 def parse_str(string):
     try:
         return float(string)
-    except:
+    except ValueError:
         prefixes = dict(prefixes_SI.items() + prefixes_IEC.items())
         for prefix, val in prefixes.items():
             if string.endswith(prefix):

--- a/graphs/__init__.py
+++ b/graphs/__init__.py
@@ -16,8 +16,8 @@ class Graphs(object):
         whoever calls this function defines how any errors are
         handled. meanwhile, loading must continue
         '''
-        from plugins import Plugin
-        import plugins
+        from .plugins import Plugin
+        from . import plugins
         errors = []
         plugins_dir = os.path.dirname(plugins.__file__)
         wd = os.getcwd()
@@ -28,7 +28,7 @@ class Graphs(object):
             module = f[:-3]
             try:
                 imp = __import__('plugins.' + module, globals(), locals(), ['*'])
-            except Exception, e:
+            except Exception, e:  # pylint: disable=W0703
                 errors.append(PluginError(module, "Failed to add plugin '%s'" % module, e))
                 continue
 
@@ -37,7 +37,7 @@ class Graphs(object):
                 if isclass(item) and item != Plugin and issubclass(item, Plugin):
                     try:
                         self.plugins.append((module, item()))
-                    except Exception, e:
+                    except Exception, e:  # pylint: disable=W0703
                         errors.append(PluginError(module, "Failed to add plugin '%s'" % module, e))
         os.chdir(wd)
         # sort plugins by their priority
@@ -47,6 +47,6 @@ class Graphs(object):
     def list_graphs(self):
         graphs = {}
         for plugin in self.plugins:
-            (plugin_name, plugin_object) = plugin
+            _plugin_name, plugin_object = plugin
             graphs.update(plugin_object.get_graphs())
         return graphs

--- a/graphs/plugins/__init__.py
+++ b/graphs/plugins/__init__.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python2
-import re
+
 """
 Base Plugin class
 """
+
+import re
+
+
+def camel_to_underscore(name):
+    '''
+    from http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-camel-case/1176023#1176023
+    '''
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
 class Plugin(object):
@@ -16,18 +26,12 @@ class Plugin(object):
             ret[k] = v['graph']
         return ret
 
-    def classname_to_tag(self):
+    @classmethod
+    def classname_to_tag(cls):
         '''
         FooBarHTTPPlugin -> foo_bar_http
         '''
-        name = self.__class__.__name__.replace('Plugin', '')
-        return self.camel_to_underscore(name)
-
-    def camel_to_underscore(self, name):
-        '''
-        from http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-camel-case/1176023#1176023
-        '''
-        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+        name = cls.__name__.replace('Plugin', '')
+        return camel_to_underscore(name)
 
 # vim: ts=4 et sw=4:

--- a/preferences_color.py
+++ b/preferences_color.py
@@ -1,4 +1,4 @@
-from colors import colors, color_variant
+from colors import colors
 from backend import get_action_on_rules_match
 
 
@@ -167,19 +167,19 @@ def apply_colors(graph):
         ]
     ]
 
-    for (i, target) in enumerate(graph['targets']):
+    for target in graph['targets']:
         tags = dict(graph['constants'].items() + graph['promoted_constants'].items() + target['variables'].items())
 
         for action in get_action_on_rules_match(rules_unique_tags, tags):
             for (tag_key, matches) in action.items():
                 t = get_unique_tag_value(graph, target, tag_key)
                 if t is not None and t in matches:
-                    graph['targets'][i]['color'] = matches[t]
+                    target['color'] = matches[t]
 
         for action in get_action_on_rules_match(rules_tags, target):
             for (tag_key, matches) in action.items():
                 t = get_tag_value(graph, target, tag_key)
                 if t is not None and t in matches:
-                    graph['targets'][i]['color'] = matches[t]
+                    target['color'] = matches[t]
 
     return graph

--- a/pylint-project.sh
+++ b/pylint-project.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+exclpats=$(grep '^[^#]' .lint_exclusions)
+
+exclusions=( -name .git )
+for exclpat in $exclpats; do exclusions+=( -o -path "./$exclpat" ); done
+
+set -e
+
+find . \( "${exclusions[@]}" \) -prune -o -name '*.py' -print0 \
+    | xargs -0r pylint --rcfile=.pylintrc
+#find . \( "${exclusions[@]}" \) -prune -o -name '*.py' -print0 \
+#    | xargs -0r pep8

--- a/query.py
+++ b/query.py
@@ -24,6 +24,7 @@ class Query(dict):
     }
 
     def __init__(self, query_str):
+        dict.__init__(self)
         tmp = copy.deepcopy(Query.default)
         self.update(tmp)
         self.parse(query_str)
@@ -43,7 +44,8 @@ class Query(dict):
                 query_str = query_str[:match.start(1)] + query_str[match.end(1):]
             return (query_str, value)
 
-        (query_str, self['statement']) = parse_val(query_str, '^', '(graph|list|stack|lines)\\b', self['statement'])
+        (query_str, self['statement']) = parse_val(query_str, '^', '(graph|list|stack|lines)\\b',
+                                                   self['statement'])
         self['statement'] = self['statement'].rstrip()
 
         (query_str, self['to']) = parse_val(query_str, 'to ', '[^ ]+', self['to'])
@@ -91,8 +93,11 @@ class Query(dict):
         sum_individual_keys = len(self['group_by']) + len(self['sum_by']) + len(self['avg_by'])
         sum_unique_keys = len(set(self['group_by'].keys() + self['sum_by'].keys() + self['avg_by'].keys()))
         if sum_individual_keys != sum_unique_keys:
-            raise Exception("'group by' (%s), 'sum by (%s)' and 'avg by (%s)' cannot list the same tag keys" %
-                            (', '.join(self['group_by'].keys()), ', '.join(self['sum_by'].keys()), ', '.join(self['avg_by'].keys())))
+            raise Exception("'group by' (%s), 'sum by (%s)' and 'avg by (%s)' "
+                            "cannot list the same tag keys" %
+                            (', '.join(self['group_by'].keys()),
+                             ', '.join(self['sum_by'].keys()),
+                             ', '.join(self['avg_by'].keys())))
         if avg_over_str is not None:
             # avg_over_str should be something like 'h', '10M', etc
             avg_over = re.match(avg_over_match, avg_over_str)

--- a/simple_match.py
+++ b/simple_match.py
@@ -53,4 +53,4 @@ def match_ast(oid, data, ast):
 # id's are matched, and the return value is a dict in the same format
 # if you use tags, make sure data['tags'] is a dict of tags or this'll blow up
 def filter_matching(ast, objects):
-    return dict((oid, data) for (oid, data) in objects.items() if match_and(oid, data, *asts))
+    return dict((oid, data) for (oid, data) in objects.items() if match_ast(oid, data, ast))

--- a/structured_metrics/plugins/catchall.py
+++ b/structured_metrics/plugins/catchall.py
@@ -2,13 +2,13 @@ from . import Plugin
 
 
 class CatchallPlugin(Plugin):
-    priority = -5
     """
     Turns metrics that aren't matched by any other plugin in something a bit more useful (than not having them at all)
     Another way to look at it is.. plugin:catchall is the list of targets you can better organize ;)
     Note that the assigned tags (i.e. source tags) are best guesses.  We can't know for sure!
     (this description goes for all catchall plugins)
     """
+    priority = -5
 
     targets = [
         {

--- a/structured_metrics/plugins/catchall_diamond.py
+++ b/structured_metrics/plugins/catchall_diamond.py
@@ -2,10 +2,10 @@ from . import Plugin
 
 
 class CatchallDiamondPlugin(Plugin):
-    priority = -4
     """
     Like catchall, but for targets from diamond (presumably)
     """
+    priority = -4
 
     targets = [
         {

--- a/structured_metrics/plugins/catchall_statsd.py
+++ b/structured_metrics/plugins/catchall_statsd.py
@@ -2,10 +2,10 @@ from . import Plugin
 
 
 class CatchallStatsdPlugin(Plugin):
-    priority = -4
     """
     Like catchall, but for targets from statsd (presumably)
     """
+    priority = -4
 
     targets = [
         {

--- a/structured_metrics/plugins/collectd.py
+++ b/structured_metrics/plugins/collectd.py
@@ -54,15 +54,15 @@ class CollectdPlugin(Plugin):
     }]
 
     @classmethod
-    def collectd_desc(self, target):
-        return self.collectd_types.get(target['tags']['type'], (target['tags']['type'], 'gauge'))
+    def collectd_desc(cls, target):
+        return cls.collectd_types.get(target['tags']['type'], (target['tags']['type'], 'gauge'))
 
     @classmethod
-    def collectd_target_type(self, target):
-        return self.collectd_desc(target)[1]
+    def collectd_target_type(cls, target):
+        return cls.collectd_desc(target)[1]
 
     @classmethod
-    def collectd_what(self, target):
-        return self.collectd_desc(target)[0]
+    def collectd_what(cls, target):
+        return cls.collectd_desc(target)[0]
 
 # vim: ts=4 et sw=4:

--- a/structured_metrics/plugins/diskspace.py
+++ b/structured_metrics/plugins/diskspace.py
@@ -10,11 +10,11 @@ class DiskspacePlugin(Plugin):
     ]
 
     def sanitize(self, target):
-        (what, type) = target['tags']['wwt'].split('_')
+        (what, mtype) = target['tags']['wwt'].split('_')
         if what == 'byte':
             what = 'bytes'
         target['tags']['what'] = what
-        target['tags']['type'] = type
+        target['tags']['type'] = mtype
         del target['tags']['wwt']
 
 # vim: ts=4 et sw=4:

--- a/structured_metrics/plugins/load.py
+++ b/structured_metrics/plugins/load.py
@@ -10,7 +10,7 @@ class LoadPlugin(Plugin):
     ]
 
     def sanitize(self, target):
-        if target['tags']['wt'] in ('01','05','15'):
+        if target['tags']['wt'] in ('01', '05', '15'):
             target['tags']['what'] = 'load'
             target['tags']['type'] = target['tags']['wt']
         if target['tags']['wt'] in ('processes_running', 'processes_total'):  # this should be ev. else

--- a/target.py
+++ b/target.py
@@ -3,6 +3,7 @@ import re
 
 class Target(dict):
     def __init__(self, src_dict):
+        dict.__init__(self)
         self['match_buckets'] = {}
         self.update(src_dict)
 

--- a/test_query.py
+++ b/test_query.py
@@ -6,7 +6,8 @@ import unittest
 class _QueryTestBase(unittest.TestCase):
     maxDiff = None
 
-    def dummyQuery(self, **dummydict):
+    @staticmethod
+    def dummyQuery(**dummydict):
         dummy = copy.deepcopy(Query.default)
         dummy.update(dummydict)
         return dummy

--- a/unitconv.py
+++ b/unitconv.py
@@ -8,7 +8,6 @@ See https://github.com/vimeo/graph-explorer/wiki/Units-%26-Prefixes
 """
 
 from __future__ import division
-from itertools import product
 
 
 si_multiplier_prefixes = (

--- a/update_metrics.py
+++ b/update_metrics.py
@@ -35,7 +35,7 @@ try:
     logger.info("generating structured metrics data...")
     backend.update_data(s_metrics)
     logger.info("success!")
-except Exception, e:
+except Exception, e:  # pylint: disable=W0703
     logger.error("sorry, something went wrong: %s", e)
     from traceback import print_exc
     print_exc()


### PR DESCRIPTION
(feel free to reject any or all of this with extreme prejudice, it won't hurt my feelings- I just find that keeping a project pylint-clean can help to avoid certain classes of bugs very well.)

None of this should have any effect on functionality, except maybe in the case of handling errors better in a few places. Most of this is:
- wrapping some of the particularly long lines
- renaming things that shadowed builtins or variables from a higher
  scope,
- simplifying loops originally written with enumerate(),
- prefixing _ to some variable names which are unused but expected to be
  unused,
- moving docstrings to the tops of their various modules/classes/
  functions so that they are treated as docstrings by Python, and
- changing some methods to staticmethods, classmethods, or plain
  functions where feasible

Adds a "pylint-project.sh" script that runs pylint on everything in the project, excluding third-party code. Could be added to a git commit hook if desired.
