### PR TITLE
Ignore OSError when tring to unlink the metrics.json file.

### DIFF
--- a/graph_explorer/backend.py
+++ b/graph_explorer/backend.py
@@ -36,7 +36,10 @@ class Backend(object):
 
         with open('%s.tmp' % self.config.filename_metrics, 'w') as m:
             m.write(response.read())
-        os.unlink(self.config.filename_metrics)
+        try:
+            os.unlink(self.config.filename_metrics)
+        except OSError:
+            pass
         os.rename('%s.tmp' % self.config.filename_metrics, self.config.filename_metrics)
 
     def load_metrics(self):


### PR DESCRIPTION
Came across an OSError when I was trying to run update_metrics.py on a newer version (current master branch) of graph-explorer. If the file is not there, update_metrics.py will always fail there, better to ignore the error in this case.

```
env PYTHONPATH=.. ./update_metrics.py 
2014-03-27 07:05:06,322 - update_metrics - INFO - fetching/saving metrics from graphite...
2014-03-27 07:05:06,427 - update_metrics - ERROR - sorry, something went wrong: [Errno 2] No such file or directory: 'metrics.json'
Traceback (most recent call last):
  File "./update_metrics.py", line 25, in <module>
    backend.download_metrics_json()
  File "/usr/local/graph-explorer/graph_explorer/backend.py", line 39, in download_metrics_json
    os.unlink(self.config.filename_metrics)
OSError: [Errno 2] No such file or directory: 'metrics.json'
```
