### PR TITLE
regexps fixed for collectd 5.x

### DIFF
--- a/graph_explorer/structured_metrics/plugins/collectd.py
+++ b/graph_explorer/structured_metrics/plugins/collectd.py
@@ -124,6 +124,15 @@ class CollectdPlugin(Plugin):
                 }
 
             },
+            {
+                'match': prefix + '(?P<server>.+?)\.(?P<collectd_plugin>conntrack)\.(?P<value>conntrack)$',
+                'target_type': 'gauge',
+                'tags': {
+                    'unit': 'entries',
+                    'what': 'conntrack'
+                }
+
+            },
         ]
         super(CollectdPlugin, self).__init__(config)
 


### PR DESCRIPTION
Collectd 5.x graphite_writer plugin produces metrics like:
collectd.host-1.memory.memory-buffered
collectd.host-1.df-root.df_complex-reserved
collectd.host-1.disk-dm-0.disk_octets.write
Original regexps doesn't match such metrics.
